### PR TITLE
Remove the composer.json entry that copies the module files into the …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,5 @@
     "psr-4": {
       "Aligent\\Pinpay\\": ""
     }
-  },
-  "extra": {
-    "map": [
-      [
-        "*",
-        "Aligent/Pinpay"
-      ]
-    ]
   }
 }


### PR DESCRIPTION
…application root directory

An entry in the composer.json was causing the module to copy files into the App directory, whilst Magento was still using the vendor directory code, meaning the module was present in the codebase twice causing fatal errors in the autoloader.

This change eliminates that issue by removing the entry causing the files to be copied.