### PR TITLE
Add missing iframe timeout configuration

### DIFF
--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -5,7 +5,7 @@ namespace Aligent\Pinpay\Model;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Payment\Helper\Data as PaymentHelper;
-use Aligent\Pinpay\Model\Payment as PinPayment;
+use Magento\Payment\Model\IframeConfigProvider;
 
 class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
 {
@@ -53,6 +53,11 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
     {
         return [
             'payment' => [
+                'iframe' => [
+                    'timeoutTime' => [
+                        $this->methodCode => IframeConfigProvider::TIMEOUT_TIME
+                    ]
+                ],
                 'pinpay' => [
                     'source' => $this->getSource(),
                     'apiKey' => $this->getApiKey(),


### PR DESCRIPTION
Fixes an issue where the timeout modal would be triggered immediately due to missing timeout configuration for the Pinpay method.

Note: the configuration below is merged with (i.e. doesn't replace) the config payload from other payment method config providers.