### PR TITLE
Floating point precision fix

### DIFF
--- a/Helper/Pinpay.php
+++ b/Helper/Pinpay.php
@@ -17,6 +17,8 @@ namespace Aligent\Pinpay\Helper;
       */
      public function getRequestAmount($currencyCode, $amount)
      {
-        return $amount * 100;
+         // Round to avoid issue where number of cents is a decimal due to
+         // floating-point precision errors.
+         return round($amount * 100);
      }
  }


### PR DESCRIPTION
Number of cents must be a whole number or transaction fails, round the number of cents to avoid floating point precision issues.