### PR TITLE
Add php 7.4 required for Magento 2.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "aligent/pinpay",
   "description": "",
   "require": {
-    "php": "~7.0.0||~7.1.0||~7.2.0||~7.3.0",
+    "php": "~7.0.0||~7.1.0||~7.2.0||~7.3.0||~7.4.0",
     "magento/magento-composer-installer": "*"
   },
   "suggest": {


### PR DESCRIPTION
Hey @indunil15 @toddhainsworth 

In the middle of a project update to 2.4.2-p1 and pulling in this newer version rather the the app/code module.

Found no 7.4 support, so hopefully a simple composer bump is ok :) 