### PR TITLE
fix bug where isActive will only ever be resolved at a default scope

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -579,7 +579,8 @@ class Payment implements MethodInterface
      */
     public function isAvailable(CartInterface $quote = null)
     {
-        return $this->isActive();
+        $storeId = $quote->getStoreId();
+        return $this->isActive($storeId);
     }
 
     /**
@@ -587,7 +588,7 @@ class Payment implements MethodInterface
      */
     public function isActive($storeId = null)
     {
-        return $this->getConfigData('active');
+        return $this->getConfigData('active', $storeId);
     }
 
     /**


### PR DESCRIPTION
this bug tends to manifest itself when creating orders in the Admin area.  `isAvailable` is called, which doesn't forward the `storeId` from the quote, meaning that `isActive` is then subsequently resolved with a store scope of `0`.